### PR TITLE
Minor Cargo.toml tweaks to enable no_std builds.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,4 @@ required-features = ["util"]
 [[test]]
 name = "integration"
 path = "tests/integration.rs"
+required-features = ["utils"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "radio-sx127x"
 description = "Rust driver for the Semtec SX127x Sub GHZ LoRa Radio ICs"
 version = "0.7.3"
 authors = ["Ryan Kurte <ryankurte@gmail.com>"]
+repository = "https://github.com/ryankurte/rust-radio-sx127x"
 license = "MPL-2.0"
 
 [features]
@@ -14,9 +15,9 @@ libc = "0.2.42"
 log = { version = "0.4.6" }
 bitflags = "1.0.4"
 embedded-hal = { version = "0.2.3", features = ["unproven"] }
-embedded-spi = "0.5.1"
+embedded-spi = { version = "0.5.1", default-features = false }
 radio = "0.4.0"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 
 structopt = { version = "0.2.15", optional = true }
 linux-embedded-hal = { version = "0.2.2", optional = true }

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ Install the utility with one of the following methods:
 - using a precompiled binary from the [releases](https://github.com/ryankurte/rust-radio-sx127x/releases/) page
 - from source using cargo with `cargo install radio-sx127x`
 
+## As a `no_std` Library
+
+The radio-sx127x crate can be used as an interface library for the sx127x radio on other
+embedded devices.  To enable `no_std` usage, add `default-features = false` to your
+`Cargo.toml`
 
 
 ## Useful Resources


### PR DESCRIPTION
- Added repository link to Cargo.toml
- Added 'default-features = false' to emedded-spi
- Added 'default-features = false' to serde
- Added brief info to README.md for no_std library building

Working on using the crate with a [B-L072Z-LRWAN1](https://www.st.com/en/evaluation-tools/b-l072z-lrwan1.html) and can compile now using
```
cargo build --target=thumbv6m-none-eabi --no-default-features --lib
```