### PR TITLE
Fix/gfsk mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ authors = ["Ryan Kurte <ryankurte@gmail.com>"]
 repository = "https://github.com/ryankurte/rust-radio-sx127x"
 license = "MPL-2.0"
 
+[package.metadata.commands]
+docker-build = "docker run --rm -it -v`pwd`:/work -v$HOME/.cargo/registry:/root/.cargo/registry ryankurte/rust-embedded /bin/bash -c \"cd /work && cargo build --target armv7-unknown-linux-gnueabihf\""
+
 [features]
 util = [ "structopt", "linux-embedded-hal", "simplelog", "humantime" ] 
 default = [ "util" ]
@@ -21,7 +24,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 
 structopt = { version = "0.2.15", optional = true }
 linux-embedded-hal = { version = "0.2.2", optional = true }
-simplelog = { version = "0.5.3", optional = true }
+simplelog = { version = "0.7.3", optional = true }
 humantime = { version = "1.2.0", optional = true }
 
 [dev-dependencies]

--- a/src/device/fsk.rs
+++ b/src/device/fsk.rs
@@ -78,7 +78,7 @@ impl Default for FskConfig {
             beacon: Beacon::Off,
             rx_afc: RxAfc::On,
             rx_agc: RxAgc::On,
-            rx_trigger: RxTrigger::Off,
+            rx_trigger: RxTrigger::PreambleDetect,
             node_address: 0,
             broadcast_address: 0,
             invert_iq: false,
@@ -258,14 +258,12 @@ pub const RXCONFIG_RESTARTRXONCOLLISION_MASK: u8 = 0x7F;
 pub const RXCONFIG_RESTARTRXONCOLLISION_ON: u8 = 0x80;
 pub const RXCONFIG_RESTARTRXONCOLLISION_OFF: u8 = 0x00; // Default
 
+pub const RXCONFIG_RESTARTRX_PLL_MASK: u8 = 0b0110_0000;
 pub const RXCONFIG_RESTARTRXWITHOUTPLLLOCK: u8 = 0x40; // Write only
-
 pub const RXCONFIG_RESTARTRXWITHPLLLOCK: u8 = 0x20; // Write only
 
 pub const RXCONFIG_AFCAUTO_MASK: u8 = 0xEF;
-
 pub const RXCONFIG_AGCAUTO_MASK: u8 = 0xF7;
-
 pub const RXCONFIG_RXTRIGER_MASK: u8 = 0xF8;
 
 /// Receive mode Auto Frequency Calibration (AFC)
@@ -290,6 +288,25 @@ pub enum RxTrigger {
     PreambleDetect = 0x06,
     RssiPreambleDetect = 0x07,
 }
+
+/// Control preamble detector state
+#[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub enum PreambleDetect {
+    On = 0x80,
+    Off = 0x00,
+}
+
+#[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub enum PreambleDetectSize {
+    /// Interrupt on one byte
+    Ps1 = 0b0000_0000,
+    /// Interrupt on two bytes
+    Ps2 = 0b0010_0000,
+    /// Interrupt on three bytes
+    Ps3 = 0b0100_0000,
+}
+
+pub const PREAMBLE_DETECTOR_TOL: u8 = 0x0A;
 
 bitflags! {
     /// Interrupt flags register 1

--- a/src/device/fsk.rs
+++ b/src/device/fsk.rs
@@ -68,8 +68,8 @@ impl Default for FskConfig {
         Self {
             preamble_len: 0x8,
             payload_len: PayloadLength::Variable,
-            dc_free: DcFree::Off,
-            crc: Crc::Off,
+            dc_free: DcFree::Whitening,
+            crc: Crc::On,
             crc_autoclear: CrcAutoClear::Off,
             address_filter: AddressFilter::Off,
             crc_whitening: CrcWhitening::Ccitt,
@@ -95,7 +95,7 @@ pub struct FskChannel {
     /// (G)FSK frequency in Hz (defaults to 434 MHz)
     pub freq: u32,
 
-    /// (G)FSK  channel baud-rate (defaults to 4.8kbps)
+    /// (G)FSK  channel baud-rate (defaults to 5kbps)
     pub br: u32,
 
     /// (G)FSK channel bandwidth
@@ -111,11 +111,11 @@ pub struct FskChannel {
 impl Default for FskChannel {
     fn default() -> Self {
         Self {
-            freq: 434e6 as u32,
-            br: 4.8e3 as u32,
+            freq: 434_000_000,
+            br: 4_800,
             bw: Bandwidth::Bw12500,
             bw_afc: Bandwidth::Bw12500,
-            fdev: 5_000_000,
+            fdev: 5_000,
         }
     }
 }
@@ -194,8 +194,8 @@ pub const CRC_AUTOCLEAR_MASK: u8 = 0x08;
 
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub enum CrcAutoClear {
-    Off = 0x00,
-    On = 0x08,
+    Off = 0x08,
+    On = 0x00,
 }
 
 pub const ADDRESS_FILTER_MASK: u8 = 0x08;

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -142,6 +142,14 @@ pub enum LongRangeMode {
     On = 0x80,
 }
 
+pub const OPMODE_MODULATION_MASK: u8 = 0b0110_0000;
+
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub enum ModulationType {
+    Fsk = 0b0000_0000,
+    Ook = 0b0010_0000,
+}
+
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum ModemMode {
     Standard,

--- a/src/fsk.rs
+++ b/src/fsk.rs
@@ -144,13 +144,16 @@ where
         // Set frequency
         self.set_frequency(channel.freq)?;
 
+        // Calculate channel configuration
+        let fdev = ((channel.fdev as f32) / device::FREQ_STEP).round() as u32;
+        let datarate = (self.config.xtal_freq as f32 / channel.br as f32).round() as u32;
+        trace!("fdev: {} bitrate: {}", fdev, datarate);
+
         // Set frequency deviation
-        let fdev = ((channel.fdev as f32) / device::FREQ_STEP) as u32;
         self.write_reg(regs::Fsk::FDEVMSB, (fdev >> 8) as u8)?;
         self.write_reg(regs::Fsk::FDEVLSB, (fdev & 0xFF) as u8)?;
 
         // Set bitrate
-        let datarate = self.config.xtal_freq / channel.br;
         self.write_reg(regs::Fsk::BITRATEMSB, (datarate >> 8) as u8)?;
         self.write_reg(regs::Fsk::BITRATELSB, (datarate & 0xFF) as u8)?;
 
@@ -242,7 +245,7 @@ where
         let s = self.get_state()?;
         let mut res = Ok(false);
 
-        debug!(
+        trace!(
             "check receive (state: {:?}, irq1: {:?} irq2: {:?})",
             s, i1, i2
         );

--- a/src/fsk.rs
+++ b/src/fsk.rs
@@ -30,7 +30,7 @@ where
         config: &FskConfig,
         channel: &FskChannel,
     ) -> Result<(), Error<CommsError, PinError>> {
-        debug!("Configuring FSK/OOK mode");
+        debug!("Configuring FSK/OOK mode: {:?} {:?}", config, channel);
 
         // Switch to sleep to change modem mode
         self.set_state(State::Sleep)?;
@@ -40,6 +40,9 @@ where
 
         // Set channel configuration
         self.fsk_set_channel(channel)?;
+
+        // Revert to standby mode
+        self.set_state(State::Standby)?;
 
         // Set preamble length
         self.write_reg(regs::Fsk::PREAMBLEMSB, (config.preamble_len >> 8) as u8)?;
@@ -81,9 +84,16 @@ where
         self.write_reg(regs::Fsk::PREAMBLEMSB, (config.preamble >> 8) as u8)?;
         self.write_reg(regs::Fsk::PREAMBLELSB, config.preamble as u8)?;
 
+        // Configure preamble detector
+        self.write_reg(regs::Fsk::PREAMBLEDETECT, 
+            PreambleDetect::On as u8 |
+            PreambleDetectSize::Ps2 as u8 | 
+            PREAMBLE_DETECTOR_TOL
+        )?;
+
         // Configure TXStart
-        self.hal.write_reg(
-            regs::Fsk::FIFOTHRESH as u8,
+        self.write_reg(
+            regs::Fsk::FIFOTHRESH,
             TX_START_FIFOLEVEL | (TX_FIFOTHRESH_MASK & 0x02),
         )?;
 
@@ -111,14 +121,16 @@ where
         let irq1 = Irq1::from_bits(reg).unwrap();
 
         if clear {
-            self.write_reg(regs::Fsk::IRQFLAGS1, reg)?;
+            self.write_reg(regs::Fsk::IRQFLAGS1, 
+                (irq1 & (Irq1::RSSI | Irq1::PREAMBLED_DETECT)).bits())?;
         }
 
         let reg = self.read_reg(regs::Fsk::IRQFLAGS2)?;
         let irq2 = Irq2::from_bits(reg).unwrap();
 
         if clear {
-            self.write_reg(regs::Fsk::IRQFLAGS2, reg)?;
+            self.write_reg(regs::Fsk::IRQFLAGS2, 
+                (irq2 & (Irq2::LOW_BAT)).bits())?;
         }
 
         Ok((irq1, irq2))
@@ -207,8 +219,9 @@ where
         let (i1, i2) = self.fsk_get_interrupts(true)?;
         debug!("clearing interrupts (irq1: {:?} irq2: {:?})", i1, i2);
 
-        // Enter Rx mode
-        self.set_state_checked(State::Rx)?;
+        // Enter Rx mode (unchecked as we enter FsRx by default)
+        // And RX on PreambleDetect (also by default)
+        self.set_state(State::Rx)?;
 
         debug!("started receive");
 
@@ -281,7 +294,7 @@ where
     /// Poll for the current channel RSSI
     /// This should only be called in receive mode
     pub(crate) fn fsk_poll_rssi(&mut self) -> Result<i16, Error<CommsError, PinError>> {
-        let raw = self.read_reg(regs::LoRa::RSSIVALUE)? as i8;
+        let raw = self.read_reg(regs::Fsk::RSSIVALUE)? as i8;
 
         let rssi = (raw / 2) as i16;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,8 +271,8 @@ where
                 self.set_state(State::Sleep)?;
                 self.update_reg(
                     regs::Common::OPMODE,
-                    device::OPMODE_LONGRANGEMODE_MASK,
-                    device::LongRangeMode::Off as u8,
+                    device::OPMODE_LONGRANGEMODE_MASK | device::OPMODE_MODULATION_MASK,
+                    device::LongRangeMode::Off as u8 | device::ModulationType::Fsk as u8,
                 )?;
             }
             ModemMode::LoRa => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ extern crate serde;
 
 use core::convert::TryFrom;
 use core::marker::PhantomData;
+use core::fmt::Debug;
 
 extern crate embedded_hal as hal;
 use hal::blocking::delay;
@@ -234,10 +235,11 @@ where
         &mut self,
         state: State,
     ) -> Result<(), Error<CommsError, PinError>> {
-        trace!("Set state to: {:?}", state);
+        trace!("Set state to: {:?} (0x{:02x})", state, state as u8);
         self.set_state(state)?;
         loop {
             let s = self.get_state()?;
+            trace!("Received: {:?}", s);
             if state == s {
                 break;
             }
@@ -296,6 +298,8 @@ where
             (channel >> 0) as u8,
         ];
 
+        debug!("Set channel to index: {:?} (freq: {:?})", channel, freq);
+
         self.hal.write_regs(regs::Common::FRFMSB as u8, &outgoing)?;
 
         Ok(())
@@ -317,6 +321,8 @@ where
     /// Calibrate the device RF chain
     /// This MUST be called directly after resetting the module
     pub(crate) fn rf_chain_calibration(&mut self) -> Result<(), Error<CommsError, PinError>> {
+        debug!("Running calibration");
+
         // Load initial PA config
         let frequency = self.get_frequency()?;
         let pa_config = self.read_reg(regs::Common::PACONFIG)?;
@@ -332,6 +338,7 @@ where
         )?;
 
         // Block on calibration complete
+        // TODO: make this fallible with a timeout?
         while self.read_reg(regs::Fsk::IMAGECAL)? & (regs::RF_IMAGECAL_IMAGECAL_RUNNING as u8) != 0
         {
         }
@@ -347,6 +354,7 @@ where
         )?;
 
         // Block on calibration complete
+        // TODO: make this fallible with a timeout?
         while self.read_reg(regs::Fsk::IMAGECAL)? & (regs::RF_IMAGECAL_IMAGECAL_RUNNING as u8) != 0
         {
         }
@@ -354,6 +362,8 @@ where
         // Restore PA config and channel
         self.set_frequency(frequency)?;
         self.write_reg(regs::Common::PACONFIG, pa_config)?;
+
+        debug!("Calibration done");
 
         Ok(())
     }
@@ -368,10 +378,6 @@ where
             hal,
             config,
             mode: Mode::Unconfigured,
-            #[cfg(feature = "ffi")]
-            c: None,
-            #[cfg(feature = "ffi")]
-            err: None,
             _ce: PhantomData,
             _pe: PhantomData,
         }
@@ -394,16 +400,22 @@ where
     /// Read a u8 value from the specified register
     pub fn read_reg<R>(&mut self, reg: R) -> Result<u8, Error<CommsError, PinError>>
     where
-        R: Copy + Clone + Into<u8>,
+        R: Copy + Clone + Debug + Into<u8>,
     {
-        self.hal.read_reg(reg.into())
+        let value = self.hal.read_reg(reg.into())?;
+
+        trace!("Read reg:   {:?} (0x{:02x}): 0x{:02x}", reg, reg.into(), value);
+
+        Ok(value)
     }
 
     /// Write a u8 value to the specified register
     pub fn write_reg<R>(&mut self, reg: R, value: u8) -> Result<(), Error<CommsError, PinError>>
     where
-        R: Copy + Clone + Into<u8>,
+        R: Copy + Clone + Debug + Into<u8>,
     {
+        trace!("Write reg:  {:?} (0x{:02x}): 0x{:02x}", reg, reg.into(), value);
+
         self.hal.write_reg(reg.into(), value)
     }
 
@@ -415,8 +427,10 @@ where
         value: u8,
     ) -> Result<u8, Error<CommsError, PinError>>
     where
-        R: Copy + Clone + Into<u8>,
+        R: Copy + Clone + Debug + Into<u8>,
     {
+        trace!("Update reg: {:?} (0x{:02x}): 0x{:02x} (0x{:02x})", reg, reg.into(), value, mask);
+
         self.hal.update_reg(reg.into(), mask, value)
     }
 }

--- a/src/lora.rs
+++ b/src/lora.rs
@@ -347,6 +347,12 @@ where
             trace!("Poll check receive, irq: {:?}", irq);
         }
 
+        let state = self.get_state()?;
+        if state != State::Rx {
+            warn!("Check receive unexpected state: {:?}", state);
+            res = Err(Error::Aborted);
+        }
+
         // Process flags
 
         if irq.contains(Irq::RX_DONE) {


### PR DESCRIPTION
Fix for #1, resolves incorrect default frequency variation calculation and `CRCAutoClear` definition, enables CRC and whitening by default.

Tested with utils.