### PR TITLE
Upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,21 +14,21 @@ util = [ "structopt", "linux-embedded-hal", "simplelog", "humantime" ]
 default = [ "util", "serde" ]
 
 [dependencies]
-libc = "0.2.42"
-log = { version = "0.4.6" }
-bitflags = "1.0.4"
-radio = "0.4.0"
-embedded-hal = { version = "0.2.3", features = ["unproven"] }
-embedded-spi = { version = "0.5.1", default-features = false }
-serde = { version = "1.0", default-features = false, features = ["derive"], optional=true }
+libc = "0.2"
+log = { version = "0.4" }
+bitflags = "1.0"
+radio = "0.7"
+embedded-hal = { version = "0.2", features = ["unproven"] }
+embedded-spi = { version = "0.6", default-features = false }
+serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 
-structopt = { version = "0.2.15", optional = true }
-linux-embedded-hal = { version = "0.2.2", optional = true }
-simplelog = { version = "0.7.3", optional = true }
-humantime = { version = "1.2.0", optional = true }
+structopt = { version = "0.3", optional = true }
+linux-embedded-hal = { version = "0.3", optional = true }
+simplelog = { version = "0.8", optional = true }
+humantime = { version = "2.0", optional = true }
 
 [dev-dependencies]
-color-backtrace = "0.1.3"
+color-backtrace = "0.4"
 
 [[bin]]
 name = "sx127x-util"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,7 @@ where
     Spi: Transfer<u8, Error = SpiError> + Write<u8, Error = SpiError>,
     CsPin: OutputPin<Error = PinError>,
     BusyPin: InputPin<Error = PinError>,
+    ReadyPin: InputPin<Error = PinError>,
     ResetPin: OutputPin<Error = PinError>,
     Delay: DelayMs<u32>,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ use core::fmt::Debug;
 extern crate embedded_hal as hal;
 use hal::blocking::delay::DelayMs;
 use hal::blocking::spi::{Transfer, Write};
-use hal::digital::v2::OutputPin;
+use hal::digital::v2::{InputPin, OutputPin};
 use hal::spi::{Mode as SpiMode, Phase, Polarity};
 
 extern crate embedded_spi;
@@ -123,6 +123,8 @@ impl<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay>
 where
     Spi: Transfer<u8, Error = SpiError> + Write<u8, Error = SpiError>,
     CsPin: OutputPin<Error = PinError>,
+    BusyPin: InputPin<Error = PinError>,
+    ResetPin: OutputPin<Error = PinError>,
     Delay: DelayMs<u32>,
 {
     /// Create an Sx127x with the provided SPI implementation and pins
@@ -136,7 +138,7 @@ where
         config: &Config,
     ) -> Result<Self, Error<SpiError, PinError>> {
         // Create SpiWrapper over spi/cs/busy/ready/reset
-        let mut hal = SpiWrapper::new(spi, cs, busy, ready, reset, delay);
+        let hal = SpiWrapper::new(spi, cs, busy, ready, reset, delay);
 
         // Create instance with new hal
         Self::new(hal, config)


### PR DESCRIPTION
Upgrade embedded-spi, structopt, radio, simplelog, humantime, color-backtrace.

I also dropped the patch versions from the cargo.toml. I've had a few headaches before dealing with mismatched match versions when a pin to the minor version is almost always fine. I can include the patch version if you prefer that though.

I was able to figure out some of the changes by looking at https://github.com/ryankurte/rust-embedded-spi/pull/2.

This doesn't compile yet though. I'm sure I'm missing something small.

```
$ cargo check --no-default-features
error[E0599]: no function or associated item named `new` found for struct `Sx127x<embedded_spi::wrapper::Wrapper<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay>, SpiError, PinError>` in the current scope
   --> src/lib.rs:142:15
    |
64  | pub struct Sx127x<Base, CommsError, PinError> {
    | --------------------------------------------- function or associated item `new` not found for this
...
142 |         Self::new(hal, config)
    |               ^^^ function or associated item not found in `Sx127x<embedded_spi::wrapper::Wrapper<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay>, SpiError, PinError>`
    | 
   ::: /Users/bwstitt/.cargo/registry/src/github.com-1ecc6299db9ec823/embedded-spi-0.6.2/src/wrapper.rs:13:1
    |
13  | pub struct Wrapper<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay> {
    | -------------------------------------------------------------------------------------- doesn't satisfy `_: base::Base<SpiError, PinError>`
    |
    = note: the method `new` exists but the following trait bounds were not satisfied:
            `embedded_spi::wrapper::Wrapper<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay>: base::Base<SpiError, PinError>`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0599`.
error: could not compile `radio-sx127x`.

To learn more, run the command again with --verbose.
```