### PR TITLE
update to e-h@1.0.0-rc.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,7 @@ path = "tests/integration.rs"
 required-features = ["utils"]
 
 [patch.crates-io]
+linux-embedded-hal = { git = "https://github.com/rust-embedded/linux-embedded-hal" }
+radio = { git = "https://github.com/rust-iot/radio" }
+driver-pal = { git = "https://github.com/rust-iot/driver-pal" }
+driver-cp2130 = { git = "https://github.com/rust-iot/rust-driver-cp2130" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ pkg-url = "{ repo }/releases/download/v{ version }/sx127x-util-{ target }.tgz"
 bin-dir = "{ bin }-{ target }{ format }"
 
 [features]
-util = [ "structopt", "driver-pal", "driver-pal/hal", "simplelog", "humantime" ] 
+util = [ "clap", "driver-pal", "driver-pal/hal", "simplelog", "humantime" ] 
 default = [ "util", "serde", "driver-pal/hal-cp2130", "driver-pal/hal-linux" ]
 
 [dependencies]
 radio = "0.11.0"
-embedded-hal = "1.0.0-alpha.7"
+embedded-hal = "1.0.0-rc.1"
 libc = "0.2"
 log = { version = "0.4" }
 bitflags = "1.0"
@@ -25,7 +25,7 @@ bitflags = "1.0"
 driver-pal = { version = "0.8.0-alpha.6", default_features = false, optional=true }
 
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
-structopt = { version = "0.3.21", optional = true }
+clap = { version = "4.4.7", optional = true, features = [ "derive" ] }
 simplelog = { version = "0.8.0", optional = true }
 humantime = { version = "2.0.0", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,5 +47,5 @@ required-features = ["utils"]
 [patch.crates-io]
 linux-embedded-hal = { git = "https://github.com/rust-embedded/linux-embedded-hal" }
 radio = { git = "https://github.com/rust-iot/radio" }
-driver-pal = { git = "https://github.com/rust-iot/driver-pal" }
+driver-pal = { git = "https://github.com/ryankurte/rust-driver-pal" }
 driver-cp2130 = { git = "https://github.com/rust-iot/rust-driver-cp2130" }

--- a/src/device/common.rs
+++ b/src/device/common.rs
@@ -1,6 +1,6 @@
 /// Payload length configuration
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum PayloadLength {
     /// Constant length payloads use implicit headers
     Constant(u16),

--- a/src/device/fsk.rs
+++ b/src/device/fsk.rs
@@ -8,7 +8,7 @@ pub use super::common::*;
 
 /// FSK and OOK mode configuration
 #[derive(Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(default))]
 pub struct FskConfig {
     /// Preamble length in symbols (defaults to 0x8)
@@ -93,7 +93,7 @@ impl Default for FskConfig {
 
 /// Fsk radio channel configuration
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(default))]
 pub struct FskChannel {
     /// (G)FSK frequency in Hz (defaults to 434 MHz)
@@ -126,7 +126,7 @@ impl Default for FskChannel {
 
 // FSK bandwidth register values
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum Bandwidth {
     Bw2600 = 0x17,
     Bw3100 = 0x0F,
@@ -156,7 +156,7 @@ pub const OPMODE_LRMODE_MASK: u8 = 0x80;
 pub const OPMODE_SHAPING_MASK: u8 = 0b0001_1000;
 
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum Shaping {
     Sh00 = 0x00,
     Sh01 = 0x08,
@@ -168,7 +168,7 @@ pub const OPMODE_MODULATION_MASK: u8 = 0b0010_0000;
 
 /// Modulation modes for the standard modem
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum Modulation {
     /// Frequency Shift Keying
     Fsk = 0x00,
@@ -183,7 +183,7 @@ pub const PACKETFORMAT_FIXED: u8 = 0x80;
 pub const DCFREE_MASK: u8 = 0x60;
 
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum DcFree {
     Off = 0x00,
     Manchester = 0x20,
@@ -193,7 +193,7 @@ pub enum DcFree {
 pub const CRC_MASK: u8 = 0x10;
 
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum Crc {
     Off = 0x00,
     On = 0x10,
@@ -202,7 +202,7 @@ pub enum Crc {
 pub const CRC_AUTOCLEAR_MASK: u8 = 0x08;
 
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum CrcAutoClear {
     Off = 0x08,
     On = 0x00,
@@ -211,7 +211,7 @@ pub enum CrcAutoClear {
 pub const ADDRESS_FILTER_MASK: u8 = 0x08;
 
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum AddressFilter {
     Off = 0x00,
     Node = 0x02,
@@ -221,7 +221,7 @@ pub enum AddressFilter {
 pub const CRC_WHITENING_MASK: u8 = 0x01;
 
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum CrcWhitening {
     Ccitt = 0x00,
     Ibm = 0x01,
@@ -230,7 +230,7 @@ pub enum CrcWhitening {
 pub const WMBUS_CRC_MASK: u8 = 0x80;
 
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum WmbusCrc {
     Off = 0x00,
     On = 0x80,
@@ -239,7 +239,7 @@ pub enum WmbusCrc {
 pub const DATAMODE_MASK: u8 = 0x40;
 
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum DataMode {
     Continuous = 0x00,
     Packet = 0x40,
@@ -248,7 +248,7 @@ pub enum DataMode {
 pub const IOHOME_MASK: u8 = 0x20;
 
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum IoHome {
     Off = 0x00,
     On = 0x20,
@@ -257,7 +257,7 @@ pub enum IoHome {
 pub const BEACON_MASK: u8 = 0x08;
 
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum Beacon {
     Off = 0x00,
     On = 0x08,
@@ -284,7 +284,7 @@ pub const RXCONFIG_RXTRIGER_MASK: u8 = 0xF8;
 
 /// Receive mode Auto Frequency Calibration (AFC)
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum RxAfc {
     On = 0x10,
     Off = 0x00,
@@ -292,7 +292,7 @@ pub enum RxAfc {
 
 /// Receive mode Auto Gain Compensation (AGC)
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum RxAgc {
     On = 0x08,
     Off = 0x00,
@@ -300,7 +300,7 @@ pub enum RxAgc {
 
 /// Receive mode trigger configuration
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum RxTrigger {
     Off = 0x00,
     Rssi = 0x01,
@@ -310,14 +310,14 @@ pub enum RxTrigger {
 
 /// Control preamble detector state
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum PreambleDetect {
     On = 0x80,
     Off = 0x00,
 }
 
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum PreambleDetectSize {
     /// Interrupt on one byte
     Ps1 = 0b0000_0000,

--- a/src/device/lora.rs
+++ b/src/device/lora.rs
@@ -8,7 +8,7 @@ pub use super::common::*;
 
 /// LoRa Radio Configuration Object
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(default))]
 pub struct LoRaConfig {
     /// LoRa Frequency hopping configuration (defaults to disabled)
@@ -41,7 +41,7 @@ impl Default for LoRaConfig {
 
 /// LoRa radio channel configuration
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(default))]
 pub struct LoRaChannel {
     /// LoRa frequency in Hz (defaults to 434 MHz)
@@ -70,7 +70,7 @@ pub const BANDWIDTH_MASK: u8 = 0b1111_0000;
 /// LoRa channel bandwidth in kHz
 #[allow(non_snake_case)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum Bandwidth {
     /// 62.5kHz bandwidth
     //Bandwidth62_5kHz = 0b0110_0000,
@@ -86,7 +86,7 @@ pub const SPREADING_FACTOR_MASK: u8 = 0b1111_0000;
 
 /// LoRa spreading factor in chips / symbol
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum SpreadingFactor {
     /// Sf6: 64 chips / symbol
     Sf6 = 0b0110_0000,
@@ -107,7 +107,7 @@ pub enum SpreadingFactor {
 pub const CODERATE_MASK: u8 = 0b0000_1110;
 
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum CodingRate {
     /// LoRa Coding rate 4/5
     Cr4_5 = 0b0000_0010,
@@ -127,7 +127,7 @@ pub const RXPAYLOADCRC_MASK: u8 = 0b0000_0100;
 
 /// Payload RX CRC configuration
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum PayloadCrc {
     Disabled = 0x00,
     Enabled = 0x04,
@@ -143,7 +143,7 @@ pub const LOWDATARATEOPTIMIZE_MASK: u8 = 0b0000_1000;
 
 /// Low datarate optimization state
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum LowDatarateOptimise {
     /// Low datarate optimizations disabled
     Disabled = 0x00,
@@ -157,7 +157,7 @@ pub const PLLHOP_FASTHOP_OFF: u8 = 0b0000_0000;
 
 /// Frequency hopping configuration
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum FrequencyHopping {
     Disabled,
     /// Enabled specifies the number of symbol periods between frequency hops
@@ -174,7 +174,7 @@ pub const AUTOMATICIF_OFF: u8 = 0b0000_0000;
 
 /// LoRa detection optimization mode
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum DetectionOptimize {
     /// Optimised for Sf7 to Sf12
     Sf7To12 = 0x03,

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -21,7 +21,7 @@ pub const OPMODE_STATE_MASK: u8 = 0b0000_0111;
 
 /// Sx127x radio configuration
 #[derive(Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Config {
     /// Device modem configuration
     pub modem: Modem,
@@ -53,7 +53,8 @@ impl Default for Config {
 
 /// LoRa Received packet information
 #[derive(Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Default)]
 pub struct PacketInfo {
     /// Received Signal Strength Indication
     pub rssi: i16,
@@ -61,11 +62,6 @@ pub struct PacketInfo {
     pub snr: Option<i16>,
 }
 
-impl Default for PacketInfo {
-    fn default() -> Self {
-        Self { rssi: 0, snr: None }
-    }
-}
 
 
 impl radio::ReceiveInfo for PacketInfo {
@@ -76,7 +72,7 @@ impl radio::ReceiveInfo for PacketInfo {
 
 /// Radio modem configuration contains fields for each modem mode
 #[derive(Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum Modem {
     /// Modem not configured
     None,
@@ -88,7 +84,7 @@ pub enum Modem {
 
 /// Radio channel configuration contains channel options for each mode
 #[derive(Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum Channel {
     /// Channel not configured
     None,
@@ -132,7 +128,7 @@ impl RadioState for State {
 
 /// Sx127x Power Amplifier (PA) configuration
 #[derive(Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct PaConfig {
     /// Power amplifier output selection (defaults to PA_BOOST output)
     pub output: PaSelect,
@@ -244,7 +240,7 @@ pub struct TxConfig {
 }
 
 /// Device frequency step
-pub const FREQ_STEP: f32 = 61.03515625;
+pub const FREQ_STEP: f32 = 61.035_156;
 
 pub const RX_BUFFER_SIZE: u32 = 256;
 
@@ -296,7 +292,7 @@ pub const PASELECT_PA_BOOST: u8 = 0b1000_0000;
 
 /// Select the power amplifier output configuration
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))] 
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum PaSelect {
     /// RFO pin, output power limited to +14dBm
     /// with specified maximum output value, defaults to 0x04 for 14dBm output

--- a/src/device/regs.rs
+++ b/src/device/regs.rs
@@ -9,9 +9,9 @@ pub enum Register {
     LoRa(LoRa),
 }
 
-impl Into<u8> for Register {
-    fn into(self) -> u8 {
-        match self {
+impl From<Register> for u8 {
+    fn from(val: Register) -> Self {
+        match val {
             Register::Common(c) => c as u8,
             Register::Fsk(f) => f as u8,
             Register::LoRa(l) => l as u8,
@@ -19,21 +19,21 @@ impl Into<u8> for Register {
     }
 }
 
-impl Into<u8> for Common {
-    fn into(self) -> u8 {
-        self as u8
+impl From<Common> for u8 {
+    fn from(val: Common) -> Self {
+        val as u8
     }
 }
 
-impl Into<u8> for LoRa {
-    fn into(self) -> u8 {
-        self as u8
+impl From<LoRa> for u8 {
+    fn from(val: LoRa) -> Self {
+        val as u8
     }
 }
 
-impl Into<u8> for Fsk {
-    fn into(self) -> u8 {
-        self as u8
+impl From<Fsk> for u8 {
+    fn from(val: Fsk) -> Self {
+        val as u8
     }
 }
 

--- a/src/lora.rs
+++ b/src/lora.rs
@@ -4,7 +4,7 @@
 //!
 //! Copyright 2019 Ryan Kurte
 
-use log::{trace, debug, warn, error};
+use log::{debug, error, trace, warn};
 
 use radio::State as _;
 
@@ -26,8 +26,8 @@ where
         debug!("Configuring lora mode");
 
         // Update internal config
-        self.config.channel = Channel::LoRa(channel.clone());
-        self.config.modem = Modem::LoRa(config.clone());
+        self.config.channel = Channel::LoRa(*channel);
+        self.config.modem = Modem::LoRa(*config);
 
         // Switch to sleep to change modem mode
         self.set_state(State::Sleep)?;
@@ -64,8 +64,8 @@ where
         }
 
         self.mode = Mode::LoRa;
-        self.config.modem = Modem::LoRa(config.clone());
-        self.config.channel = Channel::LoRa(channel.clone());
+        self.config.modem = Modem::LoRa(*config);
+        self.config.channel = Channel::LoRa(*channel);
 
         Ok(())
     }
@@ -205,7 +205,7 @@ where
         }
 
         // Update internal channel state
-        self.config.channel = Channel::LoRa(channel.clone());
+        self.config.channel = Channel::LoRa(*channel);
 
         Ok(())
     }
@@ -396,8 +396,9 @@ where
         let snr = self.read_reg(regs::LoRa::PKTSNRVALUE)? as i16;
 
         let (rssi, snr) = self.lora_process_rssi_snr(rssi, snr);
-        let info = PacketInfo{
-            rssi, snr: Some(snr),
+        let info = PacketInfo {
+            rssi,
+            snr: Some(snr),
         };
 
         trace!("FIFO RX {} bytes with fifo rx ptr: {}", n, r);

--- a/src/util/operations.rs
+++ b/src/util/operations.rs
@@ -29,13 +29,8 @@ where
         Operation::Receive(config) => {
             let mut buff = [0u8; 255];
 
-            do_receive(
-                radio,
-                &mut buff,
-                config.continuous,
-                *config.poll_interval,
-            )
-            .expect("Receive error");
+            do_receive(radio, &mut buff, config.continuous, *config.poll_interval)
+                .expect("Receive error");
         }
         Operation::Repeat(config) => {
             let mut buff = [0u8; 255];
@@ -52,8 +47,7 @@ where
         }
         Operation::Rssi(config) => {
             do_rssi(radio, config.continuous, *config.period).expect("RSSI error");
-        }
-        //_ => warn!("unsuppored command: {:?}", opts.command),
+        } //_ => warn!("unsuppored command: {:?}", opts.command),
     }
 
     Ok(())
@@ -93,7 +87,7 @@ where
 
 pub fn do_receive<T, I, E>(
     mut radio: T,
-    mut buff: &mut [u8],
+    buff: &mut [u8],
     continuous: bool,
     poll_interval: Duration,
 ) -> Result<usize, E>
@@ -106,11 +100,11 @@ where
 
     loop {
         if radio.check_receive(true)? {
-            let (n, info) = radio.get_received(&mut buff)?;
+            let (n, info) = radio.get_received(buff)?;
 
-            match std::str::from_utf8(&buff[0..n as usize]) {
+            match std::str::from_utf8(&buff[0..n]) {
                 Ok(s) => info!("Received: '{}' info: {:?}", s, info),
-                Err(_) => info!("Received: '{:?}' info: {:?}", &buff[0..n as usize], info),
+                Err(_) => info!("Received: '{:?}' info: {:?}", &buff[0..n], info),
             }
 
             if !continuous {
@@ -150,7 +144,7 @@ where
 
 pub fn do_repeat<T, I, E>(
     mut radio: T,
-    mut buff: &mut [u8],
+    buff: &mut [u8],
     power: i8,
     continuous: bool,
     delay: Duration,
@@ -168,11 +162,11 @@ where
 
     loop {
         if radio.check_receive(true)? {
-            let (n, info) = radio.get_received(&mut buff)?;
+            let (n, info) = radio.get_received(buff)?;
 
-            match std::str::from_utf8(&buff[0..n as usize]) {
+            match std::str::from_utf8(&buff[0..n]) {
                 Ok(s) => info!("Received: '{}' info: {:?}", s, info),
-                Err(_) => info!("Received: '{:?}' info: {:?}", &buff[0..n as usize], info),
+                Err(_) => info!("Received: '{:?}' info: {:?}", &buff[0..n], info),
             }
 
             std::thread::sleep(delay);

--- a/src/util/options.rs
+++ b/src/util/options.rs
@@ -1,144 +1,144 @@
+use clap::Parser;
+use driver_pal::hal::DeviceConfig;
 use humantime::Duration as HumanDuration;
 use simplelog::LevelFilter;
-use structopt::StructOpt;
-use driver_pal::hal::{DeviceConfig};
 
-#[derive(StructOpt)]
-#[structopt(name = "Sx127x-util")]
+#[derive(Parser)]
+#[clap(name = "Sx127x-util")]
 /// A Command Line Interface (CLI) for interacting with a local Sx127x radio device
 pub struct Options {
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     /// Subcommand to execute
     pub command: Command,
-    
-    #[structopt(flatten)]
+
+    #[clap(flatten)]
     pub spi_config: DeviceConfig,
 
     /// Log verbosity setting
-    #[structopt(long, default_value = "info")]
+    #[clap(long, default_value = "info")]
     pub log_level: LevelFilter,
 }
 
-#[derive(StructOpt, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 pub enum Command {
-    #[structopt(name = "chip-version")]
+    #[clap(name = "chip-version")]
     /// Fetch the device silicon/firmware version
     SiliconVersion,
 
-    #[structopt(name = "lora")]
+    #[clap(name = "lora")]
     /// LoRa mode configuration and operations
     LoRa(LoRaCommand),
 
-    #[structopt(name = "gfsk")]
+    #[clap(name = "gfsk")]
     /// GFSK mode configuration and operations
     Gfsk(GfskCommand),
 }
 
-#[derive(StructOpt, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 pub enum Operation {
-    #[structopt(name = "tx")]
+    #[clap(name = "tx")]
     /// Transmit a (string) packet
     Transmit(Transmit),
 
-    #[structopt(name = "rx")]
+    #[clap(name = "rx")]
     /// Receive a (string) packet
     Receive(Receive),
 
-    #[structopt(name = "rssi")]
+    #[clap(name = "rssi")]
     /// Poll for RSSI on the specified channel
     Rssi(Rssi),
 
-    #[structopt(name = "repeat")]
+    #[clap(name = "repeat")]
     /// Repeat received messages
     Repeat(Repeat),
 }
 
-#[derive(StructOpt, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 pub struct LoRaCommand {
     /// LoRa frequency in MHz
-    #[structopt(long = "freq-mhz")]
+    #[clap(long = "freq-mhz")]
     pub freq_mhz: Option<u32>,
 
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     /// Operation to execute
     pub operation: Operation,
 }
 
-#[derive(StructOpt, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 pub struct GfskCommand {
     /// GFSK frequency in MHz
-    #[structopt(long = "freq-mhz")]
+    #[clap(long = "freq-mhz")]
     pub freq_mhz: Option<u32>,
 
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     /// Operation to execute
     pub operation: Operation,
 }
 
-#[derive(StructOpt, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 pub struct Transmit {
     /// Data to be transmitted
-    #[structopt(long = "data")]
+    #[clap(long = "data")]
     pub data: String,
 
     /// Run continuously
-    #[structopt(long = "continuous")]
+    #[clap(long = "continuous")]
     pub continuous: bool,
 
     /// Power in dBm
-    #[structopt(long = "power", default_value = "13")]
+    #[clap(long = "power", default_value = "13")]
     pub power: i8,
 
     /// Specify period for transmission
-    #[structopt(long = "period", default_value = "1s")]
+    #[clap(long = "period", default_value = "1s")]
     pub period: HumanDuration,
 
     /// Specify period for polling for device status
-    #[structopt(long = "poll-interval", default_value = "1ms")]
+    #[clap(long = "poll-interval", default_value = "1ms")]
     pub poll_interval: HumanDuration,
 }
 
-#[derive(StructOpt, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 pub struct Receive {
     /// Run continuously
-    #[structopt(long = "continuous")]
+    #[clap(long = "continuous")]
     pub continuous: bool,
 
     /// Specify period for polling for device status
-    #[structopt(long = "poll-interval", default_value = "1ms")]
+    #[clap(long = "poll-interval", default_value = "1ms")]
     pub poll_interval: HumanDuration,
 }
 
-#[derive(StructOpt, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 pub struct Rssi {
     /// Specify period for RSSI polling
-    #[structopt(long = "period", default_value = "1s")]
+    #[clap(long = "period", default_value = "1s")]
     pub period: HumanDuration,
 
     /// Run continuously
-    #[structopt(long = "continuous")]
+    #[clap(long = "continuous")]
     pub continuous: bool,
 }
 
-#[derive(StructOpt, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 pub struct Repeat {
     /// Run continuously
-    #[structopt(long = "continuous")]
+    #[clap(long = "continuous")]
     pub continuous: bool,
 
     /// Power in dBm
-    #[structopt(long = "power", default_value = "13")]
+    #[clap(long = "power", default_value = "13")]
     pub power: i8,
 
     /// Specify period for polling for device status
-    #[structopt(long = "poll-interval", default_value = "1ms")]
+    #[clap(long = "poll-interval", default_value = "1ms")]
     pub poll_interval: HumanDuration,
 
     /// Specify delay for response message
-    #[structopt(long = "delay", default_value = "100ms")]
+    #[clap(long = "delay", default_value = "100ms")]
     pub delay: HumanDuration,
 
     /// Append RSSI and LQI to repeated message
-    #[structopt(long = "append-info")]
+    #[clap(long = "append-info")]
     pub append_info: bool,
 }


### PR DESCRIPTION
depends on a few upstream updates so testing requires a bunch of patches / CI is broken pending these updates...

```toml
[patch.crates-io]
linux-embedded-hal = { git = "https://github.com/rust-embedded/linux-embedded-hal" }
driver-pal = { git= "https://github.com/rust-iot/rust-driver-pal" }
driver-cp2130 = { git= "https://github.com/rust-driver-cp2130" }
radio = { git= "https://github.com/rust-iot/radio-hal" }
```